### PR TITLE
Fix Logitech F310 OUT endpoint (1 -> 2)

### DIFF
--- a/Sources/OpenJoystickDriverKit/Resources/Controllers/logitech-gamepad-f310.json
+++ b/Sources/OpenJoystickDriverKit/Resources/Controllers/logitech-gamepad-f310.json
@@ -14,7 +14,7 @@
       "interface": 0,
       "endpoints": {
         "in": 129,
-        "out": 1
+        "out": 2
       }
     }
   },


### PR DESCRIPTION
Closes #15. Hardware only exposes endpoint 0x02 for OUT on this device; writes to 0x01 fail (LIBUSB_ERROR_NOT_FOUND per the issue's libusb trace). Matches the in:130/out:2 pairing already used by other profiles in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Logitech Gamepad F310 controller communication by updating its USB output endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->