### PR TITLE
fix(controllers): send GIP rumble frames without the internal option flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable changes to OpenJoystickDriver are documented in this file.
 
 ### Fixed
 
+- Cleared the internal option flag from GIP rumble frames, which Xbox One
+  controllers silently discard; physical rumble on all four motors verified on
+  045E:02D1 hardware.
 - Made manual update checks select the greatest valid GitHub tag for the chosen
   stable or prerelease channel and report that remote tag when the installed
   build is already newer.

--- a/Sources/OpenJoystickDriverKit/Protocol/GIP/GIPParser.swift
+++ b/Sources/OpenJoystickDriverKit/Protocol/GIP/GIPParser.swift
@@ -158,8 +158,11 @@ public final class GIPParser: InputParser, PhysicalRumbleOutput, @unchecked Send
   ) throws {
     let seq = sequencer.next(for: GIPCommand.rumble)
     let activation: UInt8 = 0x0F  // all four motors
+    // The options byte must be 0x00: controllers silently discard rumble frames
+    // flagged with GIPOption.internal (verified on 045E:02D1 hardware), matching
+    // the unflagged rumble commands sent by the Linux xone and xpad drivers.
     let packet: [UInt8] = [
-      GIPCommand.rumble, GIPOption.internal, seq, 0x09, 0x00, activation, ltMotor, rtMotor, left,
+      GIPCommand.rumble, 0x00, seq, 0x09, 0x00, activation, ltMotor, rtMotor, left,
       right, 0x20, 0x00, 0x00,  // duration=32, delay=0, repeat=0
     ]
     _ = try handle.interruptTransfer(endpoint: outEndpoint, data: packet, timeout: 2000)


### PR DESCRIPTION
## Summary

Physical rumble on GIP (Xbox One) controllers never fires: `GIPParser.sendRumble` stamps the frame's options byte with `GIPOption.internal` (0x20), and the controller silently discards such rumble frames. Setting the options byte to 0x00 — matching the unflagged rumble commands the Linux xone/xpad drivers send — makes rumble work immediately.

One functional byte changed; also adds a changelog entry under 0.5.0-alpha.5.

## Hardware verification (model 1537, 045E:02D1, USB, macOS 26 / Apple Silicon)

Follow-up to the hardware testing in #18, using current `main` built from source:

- With the options byte 0x20 (current main): `--headless physical-output rumble` reports success but the pad never rumbles, including while provably awake (live input streaming in `--headless input watch` during the send). Four timed bursts at full intensity: nothing.
- With the options byte 0x00: all four motors respond — left main, right main, and both trigger actuators, confirmed individually per the `physical-output plan` sequence.
- A/B isolation: reverting only the duration byte while keeping options=0x00 still rumbles (short burst, as duration=32 implies) — the duration byte was never the problem.
- The 0x20 flag is not broadly rejected by this pad: LED (0x0a) and auth (0x06) frames flagged 0x20 are honored (same frames used in the #18 hardware report). The discard is specific to rumble (0x09).

Possibly worth a look separately: `keepAlive` (CMD 0x03) also sends `GIPOption.internal`. No observable harm on a wired 1537 — it runs for hours with no host→pad keep-alives at all and emits its own 0x03 frames to the host — but wireless-adapter scenarios may differ.

## Testing

- `swift build` clean
- `./scripts/ojd test parsers-macos14` → PASS (`swift test` unavailable here: CommandLineTools-only toolchain lacks Swift Testing)
- Hardware verification as above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rumble feedback for Xbox One controllers by ensuring rumble commands are accepted correctly.
  * Confirmed physical rumble functionality on verified Xbox One hardware.
* **Documentation**
  * Updated the changelog with details about the Xbox One rumble fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->