### PR TITLE
fix(driverkit): emit a kext-legal CFBundleVersion for the dext

### DIFF
--- a/scripts/build-tools/driverkit.sh
+++ b/scripts/build-tools/driverkit.sh
@@ -31,9 +31,60 @@ _require_pinned_swifterkit() {
     || die "validate driverkit requires the resolved SwifterKit dependency"
 }
 
+# DriverKit bundle versions are validated by kernelmanagerd as kext versions:
+# `major.minor.revision` with major <= 65535 and minor/revision <= 99, plus an
+# optional d/a/b/fc prerelease stage. Release packaging derives the app's
+# CFBundleVersion from the tag as a single large integer (0.5.0-beta.1 -> 500001),
+# which is not a legal kext version, so the staged dext fails validation with
+# "Property 'CFBundleVersion' must be a valid kext version" and sysextd
+# immediately uninstalls it. Derive the dext build version from the semantic
+# version instead: 0.5.0-beta.1 -> 0.5.0b1, which stays ordered below 0.5.0.
+_kext_build_version() {
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+version = sys.argv[1]
+match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$", version)
+if not match:
+    print("ERROR: DriverKit version must be SemVer without build metadata", file=sys.stderr)
+    sys.exit(2)
+
+major, minor, revision = (int(match.group(index)) for index in range(1, 4))
+if major > 65535 or minor > 99 or revision > 99:
+    print("ERROR: DriverKit version components exceed the kext version range", file=sys.stderr)
+    sys.exit(2)
+
+stages = {"dev": "d", "alpha": "a", "beta": "b", "rc": "fc"}
+prerelease = match.group(4) or ""
+suffix = ""
+if prerelease:
+    name = re.split(r"[.-]", prerelease)[0].lower()
+    stage = stages.get(name)
+    if stage is None:
+        print(f"ERROR: unsupported DriverKit prerelease stage '{name}'", file=sys.stderr)
+        sys.exit(2)
+    numbers = re.findall(r"\d+", prerelease)
+    level = int(numbers[-1]) if numbers else 1
+    if not 1 <= level <= 255:
+        print("ERROR: DriverKit prerelease level must be 1...255", file=sys.stderr)
+        sys.exit(2)
+    suffix = f"{stage}{level}"
+
+print(f"{major}.{minor}.{revision}{suffix}")
+PY
+}
+
+_require_kext_build_version() {
+  local value="$1"
+  [[ "$value" =~ ^[0-9]{1,5}(\.[0-9]{1,2}){0,2}((d|a|b|fc)[0-9]{1,3})?$ ]] \
+    || die "DriverKit CFBundleVersion '$value' is not a valid kext version"
+}
+
 _driverkit_versions() {
   DRIVERKIT_SHORT_VERSION="${OJD_BUNDLE_SHORT_VERSION:-$OJD_DEFAULT_BUNDLE_SHORT_VERSION}"
-  DRIVERKIT_BUILD_VERSION="${DEXT_BUNDLE_VERSION:-${OJD_BUNDLE_VERSION:-1}}"
+  DRIVERKIT_BUILD_VERSION="${DEXT_BUNDLE_VERSION:-$(_kext_build_version "$DRIVERKIT_SHORT_VERSION")}"
+  _require_kext_build_version "$DRIVERKIT_BUILD_VERSION"
 }
 
 generate_driverkit_project() {


### PR DESCRIPTION
## Problem

Every packaged release build ships a DriverKit extension that macOS refuses to install, so the USB path never comes up on a clean machine.

`--headless extension enable` fails with:

```
ERROR: System extension request failed: OSSystemExtensionErrorDomain code=9 extension category returned error
```

The real reason is in `kernelmanagerd`:

```
[DextValidation] Extension com.openjoystickdriver.XboxUSBDevice is not valid, error:
  Extension 'com.openjoystickdriver.XboxUSBDevice' has invalid properties:
  ["Property 'CFBundleVersion' must be a valid kext version"]
[DextValidation] Validation of com.openjoystickdriver.XboxUSBDevice error: .invalidProperties
```

`sysextd` then uninstalls the staged bundle right away:

```
extension com.openjoystickdriver.XboxUSBDevice failed to validate! uninstalling...
[com.apple.sx:StateChange] ... advancing state from validating_by_category to uninstalling
```

## Cause

`scripts/release/package.sh` `bundle_version_from_semver()` encodes the tag as one large integer:

```
0.5.0-beta.1 -> 500001
0.5.0-beta.2 -> 500002
```

`scripts/build-tools/driverkit.sh` `_driverkit_versions()` reuses that value for the dext. Kext/dext versions must be `major.minor.revision` with `major <= 65535` and `minor`/`revision <= 99`, optionally followed by a `d`/`a`/`b`/`fc` stage, so `500001` is rejected.

Local development is unaffected: `rebuild_full` uses `next_dext_bundle_version()`, which returns small integers (`1`, `2`, `3`, ...), and those are legal kext versions. Only packaged releases carry the bad value, which is why it survives CI.

Confirmed on both published builds (macOS 26, Apple Silicon):

| build | dext `CFBundleVersion` | installs |
|---|---|---|
| 0.5.0-beta.1 | `500001` | no |
| 0.5.0-beta.2 | `500002` | no |

## Fix

Derive the dext build version from the semantic version and keep the ordering:

```
0.5.0-alpha.4 -> 0.5.0a4
0.5.0-beta.1  -> 0.5.0b1
1.2.3-rc.2    -> 1.2.3fc2
0.5.0         -> 0.5.0
```

`a4 < b1 < fc1 < 0.5.0` under kext version comparison, so upgrades still move forward.

The change also fails the build when the resolved value is not a legal kext version, so a future scheme change cannot ship this silently again. An explicit `DEXT_BUNDLE_VERSION` still wins, so the monotonic local-rebuild path is untouched.

## Notes

Everything else in the app bundle checks out: Developer ID signature, notarization, `ProvisionsAllDevices` profiles, the app entitlements, and the dext personality (`idVendor` 1118, `idProductArray` including 721, interface 255/71/208). Only `CFBundleVersion` is wrong.

I could not verify the fixed value end to end, since building a loadable dext needs the signing identity for the team-owned App IDs. The version strings above are unit-checked against the kext version grammar.

Refs #18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of DriverKit build versions derived from semantic bundle versions.
  * Added validation for supported prerelease stages and version ranges.
  * Invalid explicit version overrides are now detected before project generation, providing earlier and clearer build failures.
  * Removed unsupported fallback behavior that could produce an unintended default version.

* **Chores**
  * Standardized version processing for more reliable DriverKit builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->