### PR TITLE
feat(controllers): support Razer Wolverine V3 Pro

### DIFF
--- a/Resources/ControllerOverrides/1532/1532-0a3f.json
+++ b/Resources/ControllerOverrides/1532/1532-0a3f.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/xsyetopz/OpenJoystickDriver/main/Resources/Schemas/controller-override.schema.json",
+  "operation": "add",
+  "record": {
+    "$schema": "https://raw.githubusercontent.com/xsyetopz/OpenJoystickDriver/main/Resources/Schemas/controller.schema.json",
+    "vendor_id": 5426,
+    "product_id": 2623,
+    "transport": "usb",
+    "protocol": {
+      "driver": "GIP",
+      "variant": "xboxOne"
+    },
+    "usb": {
+      "configuration": "set1-before-claim"
+    }
+  }
+}

--- a/Sources/OpenJoystickDriverHIDTool/ControllerRecordProbeRunner.swift
+++ b/Sources/OpenJoystickDriverHIDTool/ControllerRecordProbeRunner.swift
@@ -13,8 +13,8 @@ func runControllerRecordProbe(recordPath: String, seconds: Int, validateOnly: Bo
     defer { done.signal() }
     do {
       let plan = try ControllerRecordProbePlan(contentsOf: URL(fileURLWithPath: recordPath))
-      let parser = plan.makeParser()
-      printRecord(plan: plan, parser: parser)
+      let configuredParser = plan.makeParser()
+      printRecord(plan: plan, parser: configuredParser)
       if validateOnly {
         print("RECORD_VALIDATION result=valid")
         return
@@ -33,15 +33,24 @@ func runControllerRecordProbe(recordPath: String, seconds: Int, validateOnly: Bo
 
       print("USB_DEVICE service=\(device.serviceID) location=\(device.locationID)")
       if let product = device.productName { print("USB_STRING product=\(product)") }
+      let transport = await provider.resolveTransportProfile(
+        for: device,
+        configured: plan.transportProfile
+      )
+      let parser = plan.makeParser(transportProfile: transport)
+      print(
+        "USB_RESOLVED interface=\(transport.interfaceNumber)"
+          + " alternate=\(transport.alternateSetting)"
+          + " in=\(hex(transport.inputEndpoint)) out=\(hex(transport.outputEndpoint))"
+      )
       let session = try await provider.open(
         device,
-        options: USBTransportOpenOptions(transportProfile: plan.transportProfile)
+        options: USBTransportOpenOptions(transportProfile: transport)
       )
 
       if plan.transportProfile.needsSetConfiguration {
         print("USB_CONFIGURATION value=1 result=set")
       }
-      let transport = plan.transportProfile
       if transport.alternateSetting != 0 {
         print(
           "USB_ALTERNATE_SETTING interface=\(transport.interfaceNumber)"
@@ -67,6 +76,7 @@ func runControllerRecordProbe(recordPath: String, seconds: Int, validateOnly: Bo
       let summary = try await monitor(
         parser: parser,
         plan: plan,
+        transportProfile: transport,
         session: session,
         seconds: seconds
       )
@@ -125,6 +135,7 @@ private func sendStartupPackets(
 private func monitor(
   parser: any InputParser,
   plan: ControllerRecordProbePlan,
+  transportProfile: DeviceTransportProfile,
   session: any USBTransportSession,
   seconds: Int
 ) async throws -> (packets: Int, events: Int, parseErrors: Int) {
@@ -150,18 +161,22 @@ private func monitor(
 
     do {
       let bytes = try await session.readInterruptPacket(
-        endpoint: plan.transportProfile.inputEndpoint,
+        endpoint: transportProfile.inputEndpoint,
         length: 64,
         timeout: 250
       )
       packetCount += 1
       print(
-        "USB_RX endpoint=\(hex(plan.transportProfile.inputEndpoint))"
+        "USB_RX endpoint=\(hex(transportProfile.inputEndpoint))"
           + " len=\(bytes.count) bytes=\(bytes.hexBytes)"
       )
       do {
         let events = try parser.parse(data: Data(bytes))
-        try await sendLifecyclePackets(parser: parser, session: session, plan: plan)
+        try await sendLifecyclePackets(
+          parser: parser,
+          session: session,
+          transportProfile: transportProfile
+        )
         eventCount += events.count
         for event in events { print("EVENT \(String(describing: event))") }
       } catch {
@@ -177,7 +192,7 @@ private func monitor(
 private func sendLifecyclePackets(
   parser: any InputParser,
   session: any USBTransportSession,
-  plan: ControllerRecordProbePlan
+  transportProfile: DeviceTransportProfile
 ) async throws {
   guard let lifecycle = parser as? any ControllerInputConnectionLifecycle,
     let state = lifecycle.consumeInputConnectionStateChange()
@@ -186,11 +201,11 @@ private func sendLifecyclePackets(
   guard let output = parser as? any USBInputConnectionOutputProvider else { return }
   for packet in output.usbInputConnectionOutputPackets(for: state) {
     _ = try await session.writeInterruptPacket(
-      endpoint: plan.transportProfile.outputEndpoint,
+      endpoint: transportProfile.outputEndpoint,
       data: packet,
       timeout: 2_000
     )
-    print("USB_TX endpoint=\(hex(plan.transportProfile.outputEndpoint)) bytes=\(packet.hexBytes)")
+    print("USB_TX endpoint=\(hex(transportProfile.outputEndpoint)) bytes=\(packet.hexBytes)")
   }
 }
 

--- a/Sources/OpenJoystickDriverKit/Device/Discovery/ControllerDiscovery.swift
+++ b/Sources/OpenJoystickDriverKit/Device/Discovery/ControllerDiscovery.swift
@@ -389,6 +389,12 @@ public actor DeviceManager {
       let info = deviceInfos[id]
       let profile = parserRegistry.runtimeProfile(for: id)
       let ownership = info?.ownershipObservation ?? .unknown
+      let transportProfile: DeviceTransportProfile
+      if case .rawUSB = info?.discoverySource {
+        transportProfile = pipelines[id]?.transportProfile ?? profile.transportProfile
+      } else {
+        transportProfile = profile.transportProfile
+      }
       return ApplicationServiceDeviceDescription(
         name: info?.name ?? "Controller",
         vendorID: id.vendorID,
@@ -404,11 +410,11 @@ public actor DeviceManager {
         serialNumber: info?.serialNumber,
         protocolVariant: profile.protocolVariant,
         mappingFlags: profile.mappingFlags,
-        inputEndpoint: profile.transportProfile.inputEndpoint,
-        outputEndpoint: profile.transportProfile.outputEndpoint,
-        needsSetConfiguration: profile.transportProfile.needsSetConfiguration,
+        inputEndpoint: transportProfile.inputEndpoint,
+        outputEndpoint: transportProfile.outputEndpoint,
+        needsSetConfiguration: transportProfile.needsSetConfiguration,
         postHandshakeSettleMs: Int(
-          profile.transportProfile.postHandshakeSettleNanoseconds / nanosecondsPerMillisecond
+          transportProfile.postHandshakeSettleNanoseconds / nanosecondsPerMillisecond
         ),
         preferredBackends: profile.preferredBackends.map(\.rawValue),
         physicalOutputCapabilities: pipelines[id]?.physicalOutputCapabilities() ?? .none,

--- a/Sources/OpenJoystickDriverKit/Device/Discovery/USBDiscovery.swift
+++ b/Sources/OpenJoystickDriverKit/Device/Discovery/USBDiscovery.swift
@@ -110,12 +110,19 @@ extension DeviceManager {
       vendorID: device.vendorID,
       productID: device.productID
     )
-    print("[DeviceManager] USB device added: \(productName) (\(identifier))")
     let configuredTransportProfile = parserRegistry.transportProfile(for: identifier)
     let transportProfile = await provider.resolveTransportProfile(
       for: device,
       configured: configuredTransportProfile
     )
+    guard pipelines[identifier] == nil,
+      Self.matchingPhysicalIdentifier(for: identifier, among: pipelines.keys) == nil
+    else {
+      print("[DeviceManager] Pipeline already exists for \(identifier)")
+      return nil
+    }
+
+    print("[DeviceManager] USB device added: \(productName) (\(identifier))")
     deviceInfos[identifier] = DeviceInfo(
       name: productName,
       connection: "USB",

--- a/Sources/OpenJoystickDriverKit/Device/Discovery/USBDiscovery.swift
+++ b/Sources/OpenJoystickDriverKit/Device/Discovery/USBDiscovery.swift
@@ -43,7 +43,7 @@ extension DeviceManager {
         let currentServiceIDs = Set(devices.map(\.serviceIdentity))
         for device in devices where !knownServiceIDs.contains(device.serviceIdentity) {
           knownServiceIDs.insert(device.serviceIdentity)
-          if let identifier = handleUSBDeviceAdded(device, provider: provider) {
+          if let identifier = await handleUSBDeviceAdded(device, provider: provider) {
             serviceToIdentifier[device.serviceIdentity] = identifier
           }
         }
@@ -77,7 +77,7 @@ extension DeviceManager {
   @discardableResult private func handleUSBDeviceAdded(
     _ device: USBTransportDevice,
     provider: any USBTransportProvider
-  ) -> DeviceIdentifier? {
+  ) async -> DeviceIdentifier? {
     guard
       let admission = resolveRawUSBAdmission(
         parserRegistry: parserRegistry,
@@ -110,14 +110,18 @@ extension DeviceManager {
       vendorID: device.vendorID,
       productID: device.productID
     )
+    print("[DeviceManager] USB device added: \(productName) (\(identifier))")
+    let configuredTransportProfile = parserRegistry.transportProfile(for: identifier)
+    let transportProfile = await provider.resolveTransportProfile(
+      for: device,
+      configured: configuredTransportProfile
+    )
     deviceInfos[identifier] = DeviceInfo(
       name: productName,
       connection: "USB",
       serialNumber: identifier.serialNumber,
       discoverySource: .rawUSB(route: device.route)
     )
-    print("[DeviceManager] USB device added: \(productName) (\(identifier))")
-    let transportProfile = parserRegistry.transportProfile(for: identifier)
     let parser = parserRegistry.parser(for: identifier, transportProfile: transportProfile)
     let pipeline = DevicePipeline(
       identifier: identifier,

--- a/Sources/OpenJoystickDriverKit/Device/USBTransport.swift
+++ b/Sources/OpenJoystickDriverKit/Device/USBTransport.swift
@@ -97,8 +97,21 @@ public struct USBTransportDevice: Hashable, Sendable {
 /// Discovers and opens physical USB interfaces without exposing a transport framework to Kit.
 public protocol USBTransportProvider: Sendable {
   func devices() async throws -> [USBTransportDevice]
+  /// Resolves interface and endpoint facts from the connected device when the
+  /// controller record leaves them at protocol defaults.
+  func resolveTransportProfile(for device: USBTransportDevice, configured: DeviceTransportProfile)
+    async -> DeviceTransportProfile
   func open(_ device: USBTransportDevice, options: USBTransportOpenOptions) async throws
     -> any USBTransportSession
+}
+
+extension USBTransportProvider {
+  /// Keeps the catalog transport profile unchanged when a backend does not
+  /// support live USB descriptor inspection.
+  public func resolveTransportProfile(
+    for device: USBTransportDevice,
+    configured: DeviceTransportProfile
+  ) -> DeviceTransportProfile { configured }
 }
 
 /// Stable failure categories shared by USB transport implementations.
@@ -116,11 +129,23 @@ public enum USBTransportError: Error, Equatable, Sendable {
   public var isInputOutput: Bool { self == .inputOutput }
 }
 
-struct DiscoveredUSBTransport: Equatable, Sendable {
-  let interfaceNumber: UInt8
-  let alternateSetting: UInt8
-  let inputEndpoint: UInt8
-  let outputEndpoint: UInt8
+package struct DiscoveredUSBTransport: Equatable, Sendable {
+  package let interfaceNumber: UInt8
+  package let alternateSetting: UInt8
+  package let inputEndpoint: UInt8
+  package let outputEndpoint: UInt8
+
+  package init(
+    interfaceNumber: UInt8,
+    alternateSetting: UInt8,
+    inputEndpoint: UInt8,
+    outputEndpoint: UInt8
+  ) {
+    self.interfaceNumber = interfaceNumber
+    self.alternateSetting = alternateSetting
+    self.inputEndpoint = inputEndpoint
+    self.outputEndpoint = outputEndpoint
+  }
 }
 
 public struct USBEndpointTransportFacts: Equatable, Sendable {
@@ -198,7 +223,7 @@ public struct USBInterfaceTransportFacts: Equatable, Sendable {
 }
 
 public enum USBDescriptorTransportResolver {
-  static func discover(
+  package static func discover(
     interfaces: [USBInterfaceTransportFacts],
     preferredInterface: UInt8,
     requirePreferredInterface: Bool
@@ -219,9 +244,10 @@ public enum USBDescriptorTransportResolver {
     return nil
   }
 
-  static func resolve(configured: DeviceTransportProfile, discovered: DiscoveredUSBTransport?)
-    -> DeviceTransportProfile
-  {
+  package static func resolve(
+    configured: DeviceTransportProfile,
+    discovered: DiscoveredUSBTransport?
+  ) -> DeviceTransportProfile {
     guard let discovered else { return configured }
     return DeviceTransportProfile(
       inputEndpoint: configured.hasEndpointOverride

--- a/Sources/OpenJoystickDriverKit/Diagnostics/ControllerRecordProbePlan.swift
+++ b/Sources/OpenJoystickDriverKit/Diagnostics/ControllerRecordProbePlan.swift
@@ -97,6 +97,8 @@ public struct ControllerRecordProbePlan: Equatable, Sendable {
       inputEndpoint: UInt8(inputEndpoint),
       outputEndpoint: UInt8(outputEndpoint),
       interfaceNumber: UInt8(interfaceNumber),
+      hasInterfaceOverride: document.usb?.interface != nil,
+      hasEndpointOverride: document.usb?.endpoints != nil,
       needsSetConfiguration: configuration == "set1-before-claim",
       postHandshakeSettleNanoseconds: settleNanoseconds
     )
@@ -107,16 +109,18 @@ public struct ControllerRecordProbePlan: Equatable, Sendable {
     keepAlivePolicy = parsedKeepAlivePolicy
   }
 
-  public func makeParser() -> any InputParser {
+  /// Creates the record's parser with an optional live-resolved USB profile.
+  public func makeParser(transportProfile: DeviceTransportProfile? = nil) -> any InputParser {
+    let transportProfile = transportProfile ?? self.transportProfile
     switch driver {
     case .gip:
-      GIPParser(
+      return GIPParser(
         transportProfile: transportProfile,
         startupPackets: startupPackets,
         keepAlivePolicy: keepAlivePolicy
       )
     case .xbox360:
-      Xbox360Parser(
+      return Xbox360Parser(
         outEndpoint: transportProfile.outputEndpoint,
         isWirelessReceiver: isWirelessReceiver
       )

--- a/Sources/OpenJoystickDriverKit/Resources/Controllers/1532/1532-0a3f.json
+++ b/Sources/OpenJoystickDriverKit/Resources/Controllers/1532/1532-0a3f.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/xsyetopz/OpenJoystickDriver/main/Resources/Schemas/controller.schema.json",
+  "vendor_id": 5426,
+  "product_id": 2623,
+  "transport": "usb",
+  "protocol": {
+    "driver": "GIP",
+    "variant": "xboxOne"
+  },
+  "usb": {
+    "configuration": "set1-before-claim"
+  }
+}

--- a/Sources/OpenJoystickDriverUSB/IOUSBHostTransport.swift
+++ b/Sources/OpenJoystickDriverUSB/IOUSBHostTransport.swift
@@ -15,6 +15,47 @@ public actor IOUSBHostTransportProvider: USBTransportProvider {
     try Self.devices(from: Self.deviceFacts())
   }
 
+  /// Fills protocol-default interface and endpoint values from the connected
+  /// device's USB configuration descriptor.
+  public func resolveTransportProfile(
+    for device: USBTransportDevice,
+    configured: DeviceTransportProfile
+  ) -> DeviceTransportProfile {
+    guard device.route == .ioUSBHost else { return configured }
+    do {
+      let service = try Self.deviceService(for: device)
+      defer { IOObjectRelease(service) }
+      let hostDevice = try IOUSBHostDevice(
+        __ioService: service,
+        options: [],
+        queue: nil,
+        interestHandler: nil
+      )
+      defer { hostDevice.destroy() }
+      let configuration: UnsafePointer<IOUSBConfigurationDescriptor>
+      if configured.needsSetConfiguration {
+        configuration = try hostDevice.configurationDescriptor(withConfigurationValue: 1)
+      } else if let activeConfiguration = hostDevice.configurationDescriptor {
+        configuration = activeConfiguration
+      } else {
+        configuration = try hostDevice.configurationDescriptor(with: 0)
+      }
+      let discovered = USBDescriptorTransportResolver.discover(
+        interfaces: Self.transportFacts(configuration: configuration),
+        preferredInterface: configured.interfaceNumber,
+        requirePreferredInterface: configured.hasInterfaceOverride
+      )
+      return USBDescriptorTransportResolver.resolve(configured: configured, discovered: discovered)
+    } catch {
+      print(
+        "[IOUSBHost] Descriptor discovery failed for"
+          + " \(device.vendorID):\(device.productID): \(error);"
+          + " using protocol defaults/record overrides"
+      )
+      return configured
+    }
+  }
+
   public func open(_ device: USBTransportDevice, options: USBTransportOpenOptions) async throws
     -> any USBTransportSession
   {
@@ -108,6 +149,47 @@ public actor IOUSBHostTransportProvider: USBTransportProvider {
       )
     }
   }
+
+  static func transportFacts(configuration: UnsafePointer<IOUSBConfigurationDescriptor>)
+    -> [USBInterfaceTransportFacts]
+  {
+    var result: [USBInterfaceTransportFacts] = []
+    var interface = IOUSBGetNextInterfaceDescriptor(configuration, nil)
+    while let currentInterface = interface {
+      var endpoints: [USBEndpointTransportFacts] = []
+      var endpoint = IOUSBGetNextEndpointDescriptor(configuration, currentInterface, nil)
+      while let currentEndpoint = endpoint {
+        let address = currentEndpoint.pointee.bEndpointAddress
+        endpoints.append(
+          USBEndpointTransportFacts(
+            address: address,
+            isInterrupt: IOUSBGetEndpointType(currentEndpoint)
+              == UInt8(kIOUSBEndpointTypeInterrupt.rawValue),
+            isInput: address & 0x80 != 0
+          )
+        )
+        endpoint = IOUSBGetNextEndpointDescriptor(
+          configuration,
+          currentInterface,
+          descriptorHeader(currentEndpoint)
+        )
+      }
+      result.append(
+        USBInterfaceTransportFacts(
+          interfaceNumber: currentInterface.pointee.bInterfaceNumber,
+          alternateSetting: currentInterface.pointee.bAlternateSetting,
+          interfaceClass: currentInterface.pointee.bInterfaceClass,
+          endpoints: endpoints
+        )
+      )
+      interface = IOUSBGetNextInterfaceDescriptor(configuration, descriptorHeader(currentInterface))
+    }
+    return result
+  }
+
+  private static func descriptorHeader<T>(_ descriptor: UnsafePointer<T>) -> UnsafePointer<
+    IOUSBDescriptorHeader
+  > { UnsafeRawPointer(descriptor).assumingMemoryBound(to: IOUSBDescriptorHeader.self) }
 
   private static func interfaceService(for device: USBTransportDevice, interfaceNumber: UInt8)
     throws -> io_service_t?

--- a/Sources/OpenJoystickDriverUSB/TransportFacade.swift
+++ b/Sources/OpenJoystickDriverUSB/TransportFacade.swift
@@ -87,6 +87,19 @@ public actor OpenJoystickDriverUSBTransportProvider: USBTransportProvider,
     }
   }
 
+  /// Resolves transport facts through the backend selected during discovery.
+  public func resolveTransportProfile(
+    for device: USBTransportDevice,
+    configured: DeviceTransportProfile
+  ) async -> DeviceTransportProfile {
+    switch device.route {
+    case .ioUSBHost:
+      return await ioUSBHostProvider.resolveTransportProfile(for: device, configured: configured)
+    case .usbDriverKit:
+      return await usbDriverKitProvider.resolveTransportProfile(for: device, configured: configured)
+    }
+  }
+
   public func transportObservations() async throws -> [ControllerTransportObservation] {
     // Observation is deliberately best-effort. A descriptor read failure must
     // not change the exact supported-device selection or prevent diagnostics

--- a/Tests/OpenJoystickDriverKitTests/Diagnostics/ControllerRecordProbePlanTests.swift
+++ b/Tests/OpenJoystickDriverKitTests/Diagnostics/ControllerRecordProbePlanTests.swift
@@ -13,6 +13,8 @@ struct ControllerRecordProbePlanTests {
     #expect(plan.interfaceNumber == 0)
     #expect(plan.transportProfile.inputEndpoint == 130)
     #expect(plan.transportProfile.outputEndpoint == 2)
+    #expect(!plan.transportProfile.hasInterfaceOverride)
+    #expect(!plan.transportProfile.hasEndpointOverride)
     #expect(!plan.transportProfile.needsSetConfiguration)
     #expect(plan.startupPackets == GIPStartupPacket.defaultSequence)
     #expect(plan.keepAlivePolicy == .enabled)
@@ -22,6 +24,8 @@ struct ControllerRecordProbePlanTests {
   @Test func loadsRecordSelectedStartupAndTransportOptions() throws {
     let plan = try ControllerRecordProbePlan(
       data: try recordData(
+        inputEndpoint: 132,
+        outputEndpoint: 5,
         configuration: "set1-before-claim",
         settleMilliseconds: 200,
         startupPackets: ["powerOn", "xboxOneSInit", "ledOn", "authDone"]
@@ -29,6 +33,7 @@ struct ControllerRecordProbePlanTests {
     )
 
     #expect(plan.transportProfile.needsSetConfiguration)
+    #expect(plan.transportProfile.hasEndpointOverride)
     #expect(plan.transportProfile.postHandshakeSettleNanoseconds == 200_000_000)
     #expect(plan.startupPackets == [.powerOn, .xboxOneSInit, .ledOn, .authDone])
   }

--- a/Tests/OpenJoystickDriverKitTests/Protocol/Catalog/TransportProfilesTests.swift
+++ b/Tests/OpenJoystickDriverKitTests/Protocol/Catalog/TransportProfilesTests.swift
@@ -41,6 +41,22 @@ struct DeviceTransportProfileTests {
     #expect(!transport.needsSetConfiguration)
   }
 
+  @Test func testRazerWolverineV3ProUsesDescriptorEndpointsAfterConfiguration() {
+    let registry = ParserRegistry()
+    let identifier = DeviceIdentifier(vendorID: 5_426, productID: 2_623)
+
+    let runtime = registry.runtimeProfile(for: identifier)
+    let transport = registry.transportProfile(for: identifier)
+
+    #expect(runtime.parserName == "GIP")
+    #expect(runtime.protocolVariant == .xboxOne)
+    #expect(runtime.mappingFlags.isEmpty)
+    #expect(transport.inputEndpoint == 0x82)
+    #expect(transport.outputEndpoint == 0x02)
+    #expect(!transport.hasEndpointOverride)
+    #expect(transport.needsSetConfiguration)
+  }
+
   @Test func testRazerWolverineV2ProfileUsesCapturedEndpointsOnly() {
     let registry = ParserRegistry()
     let identifier = DeviceIdentifier(vendorID: 5_426, productID: 2_601)

--- a/Tests/OpenJoystickDriverKitTests/Protocol/Catalog/TransportProfilesTests.swift
+++ b/Tests/OpenJoystickDriverKitTests/Protocol/Catalog/TransportProfilesTests.swift
@@ -41,7 +41,7 @@ struct DeviceTransportProfileTests {
     #expect(!transport.needsSetConfiguration)
   }
 
-  @Test func testRazerWolverineV3ProUsesDescriptorEndpointsAfterConfiguration() {
+  @Test func testRazerWolverineV3ProProfileLeavesEndpointsUnpinned() {
     let registry = ParserRegistry()
     let identifier = DeviceIdentifier(vendorID: 5_426, productID: 2_623)
 

--- a/Tests/OpenJoystickDriverUSBTests/TransportFacadeTests.swift
+++ b/Tests/OpenJoystickDriverUSBTests/TransportFacadeTests.swift
@@ -117,6 +117,32 @@ struct TransportFacadeTests {
     #expect(await driverKit.openCount == 0)
   }
 
+  @Test func descriptorResolutionDispatchesByRecordedRoute() async {
+    let configured = DeviceTransportProfile.gipDefault
+    let discovered = DeviceTransportProfile(
+      inputEndpoint: 0x84,
+      outputEndpoint: 0x05,
+      needsSetConfiguration: true
+    )
+    let direct = FakeUSBTransportProvider(resolvedTransportProfile: discovered)
+    let driverKit = FakeUSBTransportProvider()
+    let provider = OpenJoystickDriverUSBTransportProvider(
+      ioUSBHostProvider: direct,
+      usbDriverKitProvider: driverKit,
+      supportedRawUSBModels: [USBTransportModel(vendorID: 0x1532, productID: 0x0A3F)],
+      requiredDriverKitModels: []
+    )
+
+    let resolved = await provider.resolveTransportProfile(
+      for: device(route: .ioUSBHost, serviceID: 1, vendorID: 0x1532, productID: 0x0A3F),
+      configured: configured
+    )
+
+    #expect(resolved == discovered)
+    #expect(await direct.resolveCount == 1)
+    #expect(await driverKit.resolveCount == 0)
+  }
+
   @Test func directDiscoveryUsesDeviceServiceBeforeInterfacesExist() {
     let devices = IOUSBHostTransportProvider.devices(from: [
       IOUSBHostDeviceFacts(
@@ -168,19 +194,30 @@ struct TransportFacadeTests {
 private actor FakeUSBTransportProvider: USBTransportProvider {
   private let devicesResult: Result<[USBTransportDevice], USBTransportError>
   private let openResult: Result<any USBTransportSession, USBTransportError>
+  private let resolvedTransportProfile: DeviceTransportProfile?
   private(set) var openCount = 0
+  private(set) var resolveCount = 0
 
   init(
     devicesResult: Result<[USBTransportDevice], USBTransportError> = .success([]),
     openResult: Result<any USBTransportSession, USBTransportError> = .success(
       FakeUSBTransportSession()
-    )
+    ),
+    resolvedTransportProfile: DeviceTransportProfile? = nil
   ) {
     self.devicesResult = devicesResult
     self.openResult = openResult
+    self.resolvedTransportProfile = resolvedTransportProfile
   }
 
   func devices() throws -> [USBTransportDevice] { try devicesResult.get() }
+
+  func resolveTransportProfile(for device: USBTransportDevice, configured: DeviceTransportProfile)
+    -> DeviceTransportProfile
+  {
+    resolveCount += 1
+    return resolvedTransportProfile ?? configured
+  }
 
   func open(_ device: USBTransportDevice, options: USBTransportOpenOptions) throws
     -> any USBTransportSession


### PR DESCRIPTION
## Summary

- add a generated catalog record for the Razer Wolverine V3 Pro (`1532:0A3F`)
- resolve protocol-default USB interfaces and interrupt endpoints from the connected device before opening its pipeline
- use the same resolved transport profile in the normal runtime and the documented controller-record probe

## Why this needs transport wiring

The wired controller and its 2.4 GHz receiver expose the same USB VID/PID but different interrupt endpoints:

| Connection | IN | OUT |
| --- | --- | --- |
| Wired | `0x81` | `0x01` |
| 2.4 GHz receiver | `0x84` | `0x05` |

A static controller record cannot select both layouts because catalog lookup is keyed by VID/PID. Pinning either pair would break the other connection mode.

The beta-3 branch already contains `USBDescriptorTransportResolver` and records whether interface or endpoint values were explicitly overridden. This change connects that existing resolver to IOUSBHost descriptor inspection, while preserving explicit catalog overrides and falling back to configured protocol defaults when descriptors cannot be inspected. It does not add controller-specific runtime branching or change the record schema.

## Hardware validation

Tested with a personally owned Razer Wolverine V3 Pro for Xbox/PC (RZ06-0520) on Apple Silicon and macOS 26.6.2.

- wired: configuration 1, interface 0, IN `0x81`, OUT `0x01`; GIP handshake, standard controls, all four rumble channels, and continuous-runtime reconnect passed
- 2.4 GHz: configuration 1, interface 0, IN `0x84`, OUT `0x05`; GIP handshake, standard controls, all four rumble channels, wired-to-wireless transition, and continuous-runtime reconnect passed
- input captures completed with zero parser errors
- M1-M6 were not observed as independent controls in the controller's normal onboard profile, so this change makes no extended-control support claim
- consumer-visible virtual-controller input in a game has not been verified

The full hardware pass was performed on the same change before rebasing it from beta 2 onto beta 3. Focused smoke tests were then repeated on commit `868311c` based on `release/0.5.0-beta.3`:

- wireless: resolved `0x84`/`0x05`, completed the GIP handshake on its first attempt, decoded live stick input, and finished with 1,104 packets, 1,089 events, and zero parse errors
- wired: resolved `0x81`/`0x01`, completed the GIP handshake on its first attempt, decoded A-button and live stick input, and finished with 828 packets, 830 events, and zero parse errors

## Automated validation

- `./scripts/ojd catalog regenerate --check`
- `./scripts/ojd check profiles`
- `./scripts/ojd check schemas`
- `./scripts/ojd check scripts`
- `./scripts/ojd check swift-structure`
- `./scripts/ojd lint`
- `./scripts/ojd check driverkit`
- `./scripts/ojd test parsers-macos14`
- `swift test` — 705 tests in 96 suites passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Razer Wolverine V3 Pro controller (USB vendor 5426, product 2623).
  - Added automatic USB transport discovery, including interfaces, endpoints, and configuration requirements.
  - Improved controller startup and communication by applying device-specific transport settings when available.

- **Bug Fixes**
  - Improved reliability when detecting and opening controllers whose USB settings differ from defaults.

- **Tests**
  - Added coverage for descriptor-based endpoint discovery, controller configuration, and transport routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->