### PR TITLE
feat(controllers): add Flydigi Vader 4 Pro Bluetooth support

### DIFF
--- a/Resources/ControllerOverrides/d7d7/d7d7-0041.json
+++ b/Resources/ControllerOverrides/d7d7/d7d7-0041.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/xsyetopz/OpenJoystickDriver/main/Resources/Schemas/controller-override.schema.json",
+  "operation": "add",
+  "record": {
+    "$schema": "https://raw.githubusercontent.com/xsyetopz/OpenJoystickDriver/main/Resources/Schemas/controller.schema.json",
+    "vendor_id": 55255,
+    "product_id": 65,
+    "transport": "hid",
+    "protocol": {
+      "driver": "Flydigi",
+      "variant": "flydigi"
+    }
+  }
+}

--- a/Resources/Schemas/controller.schema.json
+++ b/Resources/Schemas/controller.schema.json
@@ -51,6 +51,7 @@
 						"SteamController",
 						"SwitchPro",
 						"XboxAdaptiveJoystick",
+						"Flydigi",
 						"GenericHID"
 					]
 				},
@@ -66,6 +67,7 @@
 						"steamController",
 						"switchPro",
 						"xboxAdaptiveJoystick",
+						"flydigi",
 						"genericHID",
 						"unknown"
 					]
@@ -336,6 +338,26 @@
 								},
 								"type": "array"
 							}
+						}
+					}
+				},
+				{
+					"if": {
+						"properties": {
+							"driver": {
+								"const": "Flydigi"
+							}
+						},
+						"required": ["driver"]
+					},
+					"then": {
+						"properties": {
+							"variant": {
+								"enum": ["flydigi"]
+							}
+						},
+						"not": {
+							"required": ["quirks"]
 						}
 					}
 				},

--- a/Sources/OpenJoystickDriver/App/Presentation/Controllers/ControllerViews.swift
+++ b/Sources/OpenJoystickDriver/App/Presentation/Controllers/ControllerViews.swift
@@ -441,7 +441,7 @@
       case .xboxOriginal, .xbox360, .xbox360Wireless, .xboxOne, .xboxAdaptiveJoystick:
         return "xbox.logo"
       case .dualShock3, .dualShock4, .dualSense: return "playstation.logo"
-      case .steamController, .switchPro, .genericHID, .unknown: return "gamecontroller"
+      case .steamController, .switchPro, .flydigi, .genericHID, .unknown: return "gamecontroller"
       }
     }
 
@@ -450,7 +450,7 @@
       case .xboxOriginal, .xbox360, .xbox360Wireless, .xboxOne, .xboxAdaptiveJoystick:
         return Color(Self.xboxBrandColor)
       case .dualShock3, .dualShock4, .dualSense: return Color(Self.playStationBrandColor)
-      case .steamController, .switchPro, .genericHID, .unknown:
+      case .steamController, .switchPro, .flydigi, .genericHID, .unknown:
         return Color(NSColor.secondaryLabelColor)
       }
     }
@@ -493,6 +493,7 @@
       case .steamController:
         return OJDLocalized.string("controller.steamController", fallback: "Steam Controller")
       case .switchPro: return OJDLocalized.string("controller.switchPro", fallback: "Switch Pro")
+      case .flydigi: return OJDLocalized.string("controller.flydigi", fallback: "Flydigi")
       case .xboxAdaptiveJoystick:
         return OJDLocalized.string(
           "controller.xboxAdaptiveJoystick",

--- a/Sources/OpenJoystickDriver/App/Presentation/Controllers/InputTestControllerSymbols.swift
+++ b/Sources/OpenJoystickDriver/App/Presentation/Controllers/InputTestControllerSymbols.swift
@@ -42,6 +42,7 @@
       case .dualShock3, .dualShock4, .dualSense: return playStation
       case .switchPro: return switchController
       case .steamController: return steam
+      case .flydigi: return xbox
       case .genericHID, .unknown: return generic
       }
     }

--- a/Sources/OpenJoystickDriver/App/Presentation/Settings/DeveloperControllerSummaryView.swift
+++ b/Sources/OpenJoystickDriver/App/Presentation/Settings/DeveloperControllerSummaryView.swift
@@ -127,6 +127,7 @@
       case .dualSense: return OJDLocalized.string("controller.dualSense", fallback: "DualSense")
       case .steamController:
         return OJDLocalized.string("controller.steamController", fallback: "Steam Controller")
+      case .flydigi: return OJDLocalized.string("controller.flydigi", fallback: "Flydigi")
       case .switchPro:
         return OJDLocalized.string(
           "controller.switchProController",

--- a/Sources/OpenJoystickDriverKit/Output/Profiles/Compatibility.swift
+++ b/Sources/OpenJoystickDriverKit/Output/Profiles/Compatibility.swift
@@ -215,7 +215,7 @@ public enum AutomaticCompatibilityResolver {
     case .dualShock4: subfamily = .playStationDS4
     case .dualSense: subfamily = .playStationDS5
     case .switchPro: subfamily = .nintendoSwitchPro
-    case .genericHID, .dualShock3, .steamController, .unknown: subfamily = .other
+    case .genericHID, .dualShock3, .steamController, .flydigi, .unknown: subfamily = .other
     }
     return subfamily
   }

--- a/Sources/OpenJoystickDriverKit/Protocol/Catalog/ControllerRecordDocument.swift
+++ b/Sources/OpenJoystickDriverKit/Protocol/Catalog/ControllerRecordDocument.swift
@@ -130,7 +130,7 @@ struct ControllerRecordDocument: Decodable {
       ), "SwitchPro": (["switchPro", "unknown"], ["usbHandshake", "calibration", "imu", "rumble"]),
       "XboxAdaptiveJoystick": (
         ["xboxAdaptiveJoystick", "unknown"], ["rawUSBPackets", "genericHIDPackets"]
-      ), "GenericHID": (["genericHID"], [])
+      ), "Flydigi": (["flydigi"], []), "GenericHID": (["genericHID"], [])
     ]
   }
 

--- a/Sources/OpenJoystickDriverKit/Protocol/Catalog/ParserRegistry.swift
+++ b/Sources/OpenJoystickDriverKit/Protocol/Catalog/ParserRegistry.swift
@@ -45,6 +45,7 @@ public final class ParserRegistry: Sendable {
         isWirelessReceiver: runtimeProfile.quirks.contains("wirelessReceiver")
       )
     case "SwitchPro": return SwitchProParser()
+    case "Flydigi": return FlydigiParser()
     case "Xbox360":
       return Xbox360Parser(
         outEndpoint: transportProfile.outputEndpoint,

--- a/Sources/OpenJoystickDriverKit/Protocol/Catalog/TransportProfiles.swift
+++ b/Sources/OpenJoystickDriverKit/Protocol/Catalog/TransportProfiles.swift
@@ -58,6 +58,7 @@ public enum ControllerProtocolVariant: String, Codable, Hashable, Sendable {
   case steamController
   case switchPro
   case xboxAdaptiveJoystick
+  case flydigi
   case genericHID
   case unknown
 }

--- a/Sources/OpenJoystickDriverKit/Protocol/Classification/USBProtocolClassification.swift
+++ b/Sources/OpenJoystickDriverKit/Protocol/Classification/USBProtocolClassification.swift
@@ -211,7 +211,8 @@ public enum KnownRecordProtocolReconciler {
       case .xbox360, .xbox360Wireless, .xboxAdaptiveJoystick: .xusb
       case .xboxOriginal: nil
       case .xboxOne: .gip
-      case .genericHID, .dualShock3, .dualShock4, .dualSense, .steamController, .switchPro:
+      case .genericHID, .dualShock3, .dualShock4, .dualSense, .steamController, .switchPro,
+        .flydigi:
         .genericHID
       case .unknown: nil
       }

--- a/Sources/OpenJoystickDriverKit/Protocol/Parsers/FlydigiParser.swift
+++ b/Sources/OpenJoystickDriverKit/Protocol/Parsers/FlydigiParser.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+private let flydigiInputReportID: UInt8 = 0x01
+private let flydigiReportLength = 15
+private let flydigiAxisDeadzone: Float = 0.08
+private let flydigiAxisMagnitude: Float = 127
+private let flydigiTriggerMax: Float = 255
+private let flydigiHatNeutral: UInt8 = 0
+
+/// Parser for Flydigi Vader-family controllers on Bluetooth Low Energy.
+///
+/// The report declares GamePad usage and standard Generic Desktop axes, but
+/// packs the right stick into Z/Rz and the analog triggers into the Simulation
+/// page, so the descriptor-driven fallback maps neither correctly. Button
+/// usages are also non-contiguous, which shifts every index after the first
+/// gap. This parser reads the observed 15-byte layout by offset instead.
+public final class FlydigiParser: InputParser, @unchecked Sendable {
+
+  private enum ReportOffset {
+    static let leftStickX: Int = 1
+    static let leftStickY: Int = 2
+    static let rightStickX: Int = 3
+    static let rightStickY: Int = 4
+    /// Low nibble is the D-pad hat; high nibble carries the face buttons.
+    static let hatAndFace: Int = 9
+    static let shoulders: Int = 10
+    static let extras: Int = 11
+    static let system: Int = 12
+    static let leftTrigger: Int = 13
+    static let rightTrigger: Int = 14
+  }
+
+  private enum FaceMask {
+    static let a: UInt8 = 0x10
+    static let b: UInt8 = 0x20
+    static let x: UInt8 = 0x40
+    static let y: UInt8 = 0x80
+  }
+
+  private enum ShoulderMask {
+    static let leftBumper: UInt8 = 0x01
+    static let rightBumper: UInt8 = 0x02
+    static let leftTrigger: UInt8 = 0x04
+    static let rightTrigger: UInt8 = 0x08
+    static let back: UInt8 = 0x10
+    static let start: UInt8 = 0x20
+    static let leftStick: UInt8 = 0x40
+    static let rightStick: UInt8 = 0x80
+  }
+
+  private enum SystemMask {
+    static let guide: UInt8 = 0x80
+  }
+
+  private var prevHatAndFace: UInt8 = 0
+  private var prevShoulders: UInt8 = 0
+  private var prevSystem: UInt8 = 0
+  private var prevLeftTrigger: UInt8 = 0
+  private var prevRightTrigger: UInt8 = 0
+  private var prevLeftStickX: UInt8 = 0xFF
+  private var prevLeftStickY: UInt8 = 0xFF
+  private var prevRightStickX: UInt8 = 0xFF
+  private var prevRightStickY: UInt8 = 0xFF
+  private let stateLock = NSLock()
+
+  /// Creates a new FlydigiParser.
+  public init() {}
+
+  /// No-op because the controller streams input without a handshake.
+  public func performHandshake(handle: (any USBTransportSession)?) throws {
+    // Required by InputParser; Flydigi BLE needs no handshake.
+  }
+
+  /// Parses one Flydigi input report and returns zero or more controller events.
+  public func parse(data: Data) throws -> [ControllerEvent] {
+    let bytes = reportPayload(from: data)
+    guard bytes.count >= flydigiReportLength else { return [] }
+
+    return stateLock.withLock {
+      var events: [ControllerEvent] = []
+      events += faceEvents(bytes[ReportOffset.hatAndFace])
+      events += hatEvents(bytes[ReportOffset.hatAndFace])
+      events += shoulderEvents(bytes[ReportOffset.shoulders])
+      events += systemEvents(bytes[ReportOffset.system])
+      events += triggerEvents(bytes)
+      events += stickEvents(bytes)
+      prevHatAndFace = bytes[ReportOffset.hatAndFace]
+      prevShoulders = bytes[ReportOffset.shoulders]
+      prevSystem = bytes[ReportOffset.system]
+      prevLeftTrigger = bytes[ReportOffset.leftTrigger]
+      prevRightTrigger = bytes[ReportOffset.rightTrigger]
+      prevLeftStickX = bytes[ReportOffset.leftStickX]
+      prevLeftStickY = bytes[ReportOffset.leftStickY]
+      prevRightStickX = bytes[ReportOffset.rightStickX]
+      prevRightStickY = bytes[ReportOffset.rightStickY]
+      return events
+    }
+  }
+
+  /// Strips the leading report ID when IOKit delivers it inline.
+  private func reportPayload(from data: Data) -> [UInt8] {
+    let bytes = [UInt8](data)
+    guard bytes.count == flydigiReportLength, bytes.first == flydigiInputReportID else {
+      return bytes
+    }
+    return bytes
+  }
+
+  /// Maps the A, B, X, and Y bits packed into the high nibble of byte 9.
+  private func faceEvents(_ value: UInt8) -> [ControllerEvent] {
+    var events: [ControllerEvent] = []
+    let pairs: [(UInt8, Button)] = [
+      (FaceMask.a, .a), (FaceMask.b, .b), (FaceMask.x, .x), (FaceMask.y, .y)
+    ]
+    for (mask, button) in pairs {
+      events += transition(mask: mask, current: value, previous: prevHatAndFace, button: button)
+    }
+    return events
+  }
+
+  /// Maps bumpers, Select, Start, and stick clicks. The trigger bits in this
+  /// byte are handled by ``triggerEvents(_:)`` instead.
+  private func shoulderEvents(_ value: UInt8) -> [ControllerEvent] {
+    var events: [ControllerEvent] = []
+    let pairs: [(UInt8, Button)] = [
+      (ShoulderMask.leftBumper, .leftBumper),
+      (ShoulderMask.rightBumper, .rightBumper),
+      (ShoulderMask.back, .back),
+      (ShoulderMask.start, .start),
+      (ShoulderMask.leftStick, .leftStick),
+      (ShoulderMask.rightStick, .rightStick)
+    ]
+    for (mask, button) in pairs {
+      events += transition(mask: mask, current: value, previous: prevShoulders, button: button)
+    }
+    return events
+  }
+
+  /// Maps the Home button, which is the only control in byte 12.
+  private func systemEvents(_ value: UInt8) -> [ControllerEvent] {
+    transition(mask: SystemMask.guide, current: value, previous: prevSystem, button: .guide)
+  }
+
+  /// Emits a press or release only when the masked bit changed.
+  private func transition(mask: UInt8, current: UInt8, previous: UInt8, button: Button)
+    -> [ControllerEvent]
+  {
+    let isPressed = current & mask != 0
+    guard isPressed != (previous & mask != 0) else { return [] }
+    return [isPressed ? .buttonPressed(button) : .buttonReleased(button)]
+  }
+
+  /// The D-pad is a 4-bit hat in the low nibble, 1 = up and increasing clockwise.
+  private func hatEvents(_ value: UInt8) -> [ControllerEvent] {
+    let hat = value & 0x0F
+    guard hat != prevHatAndFace & 0x0F else { return [] }
+    return [.dpadChanged(Self.direction(for: hat))]
+  }
+
+  /// Converts a hat value to a compass direction; anything outside 1...8 is neutral.
+  private static func direction(for hat: UInt8) -> DpadDirection {
+    switch hat {
+    case 1: return .north
+    case 2: return .northEast
+    case 3: return .east
+    case 4: return .southEast
+    case 5: return .south
+    case 6: return .southWest
+    case 7: return .west
+    case 8: return .northWest
+    default: return .neutral
+    }
+  }
+
+  /// The digital bit in the shoulder byte tracks the analog value, so the
+  /// analog byte alone drives the reported trigger position.
+  private func triggerEvents(_ bytes: [UInt8]) -> [ControllerEvent] {
+    var events: [ControllerEvent] = []
+    let left = bytes[ReportOffset.leftTrigger]
+    let right = bytes[ReportOffset.rightTrigger]
+    if left != prevLeftTrigger {
+      events.append(.leftTriggerChanged(Float(left) / flydigiTriggerMax))
+    }
+    if right != prevRightTrigger {
+      events.append(.rightTriggerChanged(Float(right) / flydigiTriggerMax))
+    }
+    return events
+  }
+
+  /// Emits a stick event when either axis of that stick moved, so paired
+  /// coordinates stay consistent.
+  private func stickEvents(_ bytes: [UInt8]) -> [ControllerEvent] {
+    var events: [ControllerEvent] = []
+    let leftChanged =
+      bytes[ReportOffset.leftStickX] != prevLeftStickX
+      || bytes[ReportOffset.leftStickY] != prevLeftStickY
+    if leftChanged {
+      events.append(
+        .leftStickChanged(
+          x: Self.axis(bytes[ReportOffset.leftStickX]),
+          y: Self.axis(bytes[ReportOffset.leftStickY])
+        )
+      )
+    }
+    let rightChanged =
+      bytes[ReportOffset.rightStickX] != prevRightStickX
+      || bytes[ReportOffset.rightStickY] != prevRightStickY
+    if rightChanged {
+      events.append(
+        .rightStickChanged(
+          x: Self.axis(bytes[ReportOffset.rightStickX]),
+          y: Self.axis(bytes[ReportOffset.rightStickY])
+        )
+      )
+    }
+    return events
+  }
+
+  /// Converts one signed axis byte to -1...1, where the hardware reports
+  /// negative for up and left.
+  static func axis(_ raw: UInt8) -> Float {
+    let signed = Float(Int8(bitPattern: raw))
+    let normalized = max(-1, min(1, signed / flydigiAxisMagnitude))
+    return abs(normalized) < flydigiAxisDeadzone ? 0 : normalized
+  }
+}

--- a/Sources/OpenJoystickDriverKit/Resources/Controllers/d7d7/d7d7-0041.json
+++ b/Sources/OpenJoystickDriverKit/Resources/Controllers/d7d7/d7d7-0041.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/xsyetopz/OpenJoystickDriver/main/Resources/Schemas/controller.schema.json",
+  "vendor_id": 55255,
+  "product_id": 65,
+  "transport": "hid",
+  "protocol": {
+    "driver": "Flydigi",
+    "variant": "flydigi"
+  }
+}

--- a/Sources/OpenJoystickDriverKit/Resources/Localization/Localizable.template.strings
+++ b/Sources/OpenJoystickDriverKit/Resources/Localization/Localizable.template.strings
@@ -660,6 +660,7 @@
 "controller.dualSense" = "DualSense";
 "controller.dualShock3" = "DualShock 3";
 "controller.dualShock4" = "DualShock 4";
+"controller.flydigi" = "Flydigi";
 "controller.genericHID" = "Generic HID";
 "controller.originalXbox" = "Original Xbox";
 "controller.standardHID" = "Standard HID";

--- a/Tests/OpenJoystickDriverKitTests/Protocol/Parsers/FlydigiParserTests.swift
+++ b/Tests/OpenJoystickDriverKitTests/Protocol/Parsers/FlydigiParserTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import Testing
+
+@testable import OpenJoystickDriverKit
+
+/// Reports captured from a Flydigi Vader 4 Pro over Bluetooth Low Energy,
+/// firmware 6.9.5.5, on macOS 26.5.
+private enum CapturedReport {
+  static let neutral: [UInt8] = [
+    0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  ]
+
+  static func with(
+    leftStickX: UInt8 = 0xFF,
+    leftStickY: UInt8 = 0xFF,
+    rightStickX: UInt8 = 0xFF,
+    rightStickY: UInt8 = 0xFF,
+    hatAndFace: UInt8 = 0,
+    shoulders: UInt8 = 0,
+    extras: UInt8 = 0,
+    system: UInt8 = 0,
+    leftTrigger: UInt8 = 0,
+    rightTrigger: UInt8 = 0
+  ) -> Data {
+    var report = neutral
+    report[1] = leftStickX
+    report[2] = leftStickY
+    report[3] = rightStickX
+    report[4] = rightStickY
+    report[9] = hatAndFace
+    report[10] = shoulders
+    report[11] = extras
+    report[12] = system
+    report[13] = leftTrigger
+    report[14] = rightTrigger
+    return Data(report)
+  }
+}
+
+private func settled(_ parser: FlydigiParser) {
+  _ = try? parser.parse(data: Data(CapturedReport.neutral))
+}
+
+@Suite struct FlydigiParserTests {
+
+  @Test func testNeutralReportEmitsNoEvents() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    #expect(try parser.parse(data: Data(CapturedReport.neutral)).isEmpty)
+  }
+
+  @Test func testShortReportIsIgnored() throws {
+    let parser = FlydigiParser()
+    #expect(try parser.parse(data: Data([0x01, 0xFF, 0xFF])).isEmpty)
+  }
+
+  /// The hardware reports 0x80 when the stick is pushed fully up, so the
+  /// normalized value stays negative and is not flipped.
+  @Test func testLeftStickUpIsNegativeY() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(leftStickY: 0x80))
+    #expect(events.contains { event in
+      if case .leftStickChanged(_, let y) = event { return y < -0.9 }
+      return false
+    })
+  }
+
+  @Test func testLeftStickRightIsPositiveX() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(leftStickX: 0x7F))
+    #expect(events.contains { event in
+      if case .leftStickChanged(let x, _) = event { return x > 0.9 }
+      return false
+    })
+  }
+
+  /// Bytes 3 and 4 are the right stick, not the triggers the descriptor implies.
+  @Test func testRightStickUsesZAndRzBytes() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(rightStickX: 0x7F, rightStickY: 0x80))
+    #expect(events.contains { event in
+      if case .rightStickChanged(let x, let y) = event { return x > 0.9 && y < -0.9 }
+      return false
+    })
+  }
+
+  @Test func testRightStickDeflectionEmitsNoTriggerEvent() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(rightStickX: 0x7F))
+    #expect(!events.contains { event in
+      if case .leftTriggerChanged = event { return true }
+      if case .rightTriggerChanged = event { return true }
+      return false
+    })
+  }
+
+  @Test func testAnalogTriggersUseSimulationBytes() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let left = try parser.parse(data: CapturedReport.with(shoulders: 0x04, leftTrigger: 0xFF))
+    #expect(left.contains { $0 == .leftTriggerChanged(1.0) })
+
+    settled(parser)
+    let right = try parser.parse(data: CapturedReport.with(shoulders: 0x08, rightTrigger: 0xFF))
+    #expect(right.contains { $0 == .rightTriggerChanged(1.0) })
+  }
+
+  /// The digital trigger bit accompanies the analog value and must not be
+  /// reported as a stick click.
+  @Test func testDigitalTriggerBitIsNotAStickClick() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(shoulders: 0x04, leftTrigger: 0xFF))
+    #expect(!events.contains { $0 == .buttonPressed(.leftStick) })
+  }
+
+  @Test func testFaceButtonsUseHighNibble() throws {
+    let cases: [(UInt8, Button)] = [(0x10, .a), (0x20, .b), (0x40, .x), (0x80, .y)]
+    for (mask, button) in cases {
+      let parser = FlydigiParser()
+      settled(parser)
+      let events = try parser.parse(data: CapturedReport.with(hatAndFace: mask))
+      #expect(events.contains { $0 == .buttonPressed(button) })
+    }
+  }
+
+  @Test func testShoulderByteButtons() throws {
+    let cases: [(UInt8, Button)] = [
+      (0x01, .leftBumper), (0x02, .rightBumper), (0x10, .back), (0x20, .start),
+      (0x40, .leftStick), (0x80, .rightStick)
+    ]
+    for (mask, button) in cases {
+      let parser = FlydigiParser()
+      settled(parser)
+      let events = try parser.parse(data: CapturedReport.with(shoulders: mask))
+      #expect(events.contains { $0 == .buttonPressed(button) })
+    }
+  }
+
+  @Test func testGuideUsesSystemByte() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(system: 0x80))
+    #expect(events.contains { $0 == .buttonPressed(.guide) })
+  }
+
+  /// The D-pad is a 4-bit hat in the low nibble, clockwise from 1 = up.
+  @Test func testHatDirections() throws {
+    let cases: [(UInt8, DpadDirection)] = [
+      (1, .north), (3, .east), (5, .south), (7, .west), (0, .neutral)
+    ]
+    for (value, direction) in cases {
+      let parser = FlydigiParser()
+      _ = try parser.parse(data: CapturedReport.with(hatAndFace: 2))
+      let events = try parser.parse(data: CapturedReport.with(hatAndFace: value))
+      #expect(events.contains { $0 == .dpadChanged(direction) })
+    }
+  }
+
+  /// The hat shares its byte with the face buttons, so one must not disturb
+  /// the other.
+  @Test func testHatAndFaceButtonCoexist() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    let events = try parser.parse(data: CapturedReport.with(hatAndFace: 0x10 | 3))
+    #expect(events.contains { $0 == .buttonPressed(.a) })
+    #expect(events.contains { $0 == .dpadChanged(.east) })
+  }
+
+  @Test func testButtonReleaseEmitsReleaseEvent() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    _ = try parser.parse(data: CapturedReport.with(hatAndFace: 0x10))
+    let events = try parser.parse(data: Data(CapturedReport.neutral))
+    #expect(events.contains { $0 == .buttonReleased(.a) })
+  }
+
+  @Test func testRepeatedReportEmitsNoDuplicateEvents() throws {
+    let parser = FlydigiParser()
+    settled(parser)
+    _ = try parser.parse(data: CapturedReport.with(hatAndFace: 0x10))
+    #expect(try parser.parse(data: CapturedReport.with(hatAndFace: 0x10)).isEmpty)
+  }
+
+  @Test func testRestingAxisJitterStaysInDeadzone() {
+    #expect(FlydigiParser.axis(0xFF) == 0)
+    #expect(FlydigiParser.axis(0x00) == 0)
+    #expect(FlydigiParser.axis(0x7F) > 0.9)
+    #expect(FlydigiParser.axis(0x80) < -0.9)
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 - [Razer Wolverine V2](testing/razer/wolverine-v2.md)
 - [Razer Wolverine V3 TE](testing/razer/v3-te.md)
 - [Nacon Revolution X Pro](testing/nacon-revolution-x.md)
+- [Flydigi Vader 4 Pro](testing/flydigi-vader-4-pro.md)
 - [Steam Controller](testing/steam-controller.md)
 - [Xbox 360 wireless receiver](testing/xbox-360-wireless-receiver.md)
 - [Xbox Adaptive Joystick](testing/xbox-adaptive-joystick.md)

--- a/docs/testing/flydigi-vader-4-pro.md
+++ b/docs/testing/flydigi-vader-4-pro.md
@@ -1,0 +1,80 @@
+# Flydigi Vader 4 Pro (Bluetooth)
+
+Bluetooth Low Energy identity `D7D7:0041`, firmware 6.9.5.5, observed on
+macOS 26.5. The 2.4 GHz dongle and wired modes enumerate as different
+identities and are not covered by this record.
+
+## Why the record exists
+
+The device advertises Generic Desktop GamePad usage, so descriptor-driven
+discovery finds it, but three descriptor properties defeat the generic parser:
+
+- the right stick is published on `Z`/`Rz`, which the generic parser maps to
+  triggers;
+- the analog triggers are published on Simulation page `0x02` as Brake and
+  Accelerator, which the generic parser does not read;
+- button usages are non-contiguous (1, 2, 4, 5, 7…15), so every index after
+  the first gap shifts.
+
+Observed generic-parser behavior before the record: right stick drove the
+triggers, LT and RT reported stick clicks, X reported Y, Y reported left
+bumper, RB reported Start, LB reported Back, Select reported Guide, Start
+reported nothing, and left-stick Y was inverted. The D-pad was correct.
+
+## Report layout
+
+Report ID `0x01`, 15 bytes. Neutral:
+`01 FF FF FF FF 00 00 00 00 00 00 00 00 00 00`.
+
+| Offset | Contents |
+| --- | --- |
+| 1 | Left stick X, signed, `0x7F` right |
+| 2 | Left stick Y, signed, `0x80` up |
+| 3 | Right stick X, signed, `0x7F` right |
+| 4 | Right stick Y, signed, `0x80` up |
+| 9 | Low nibble D-pad hat, `1` up increasing clockwise; `0x10` A, `0x20` B, `0x40` X, `0x80` Y |
+| 10 | `0x01` LB, `0x02` RB, `0x04` LT digital, `0x08` RT digital, `0x10` Select, `0x20` Start, `0x40` L3, `0x80` R3 |
+| 11 | `0x01` C, `0x02` Z, `0x04` M1, `0x08` M2, `0x10` M3, `0x20` M4 |
+| 12 | `0x80` Home |
+| 13 | Left trigger, unsigned `0...255` |
+| 14 | Right trigger, unsigned `0...255` |
+
+Bytes 5 through 8 were `0x00` in every observed report.
+
+The digital trigger bits in byte 10 accompany the analog values rather than
+replacing them, so the parser reads position from bytes 13 and 14 only.
+
+C, Z, and M1 through M4 are decoded but have no `Button` case and no bit in
+the 16-button compatibility report, so they do not reach a consumer.
+
+## Status
+
+Input decoding is verified against captured reports for every control in the
+table. Not yet verified on this hardware:
+
+- consumer-visible input through a signed build and the virtual device;
+- reconnect after the controller sleeps;
+- rumble or any other physical output;
+- the 2.4 GHz dongle and wired identities.
+
+## Procedure
+
+Pair the controller over Bluetooth, then confirm the runtime selects this
+record rather than the generic fallback:
+
+```bash
+/Applications/OpenJoystickDriver.app/Contents/MacOS/OpenJoystickDriver \
+  --headless controller list
+```
+
+The entry should report `protocol=flydigi`. Then check each control:
+
+```bash
+/Applications/OpenJoystickDriver.app/Contents/MacOS/OpenJoystickDriver \
+  --headless controller state
+```
+
+Push the left stick fully up and confirm the reported Y is negative. Deflect
+the right stick and confirm the triggers stay at rest. Press each face button,
+bumper, stick click, Select, Start, and Home in turn and confirm the reported
+name matches the physical label.


### PR DESCRIPTION
## Summary

Adds a record and parser for the Flydigi Vader 4 Pro over Bluetooth Low Energy,
identity `D7D7:0041`. The controller is discovered today, but every control
except the D-pad is mismapped by the Generic HID fallback.

I own the hardware and captured the report map below from it. I used an AI
coding assistant (Claude) for the implementation.

## The problem

The device advertises Generic Desktop GamePad usage, so descriptor-driven
discovery finds it. Three descriptor properties then defeat `GenericHIDParser`:

- the right stick is published on `Z`/`Rz`, which the generic parser maps to
  triggers;
- the analog triggers are published on Simulation page `0x02` (Brake and
  Accelerator), which the generic parser does not read;
- button usages are non-contiguous — 1, 2, 4, 5, 7…15, skipping 3, 6, and 13 —
  so indexing by usage number shifts every button after the first gap.

Observed on hardware before this change:

| Physical control | Reported as |
| --- | --- |
| Right stick X / Y | left trigger / right trigger |
| LT / RT | left stick click / right stick click |
| X | Y |
| Y | left bumper |
| RB | Start |
| LB | Back |
| Select | Guide |
| Start | nothing |
| L3 / R3 | nothing |
| Left stick Y | inverted |
| D-pad | correct |

The hardware reports `0x80` for left-stick Y pushed fully up, which is the
conventional signed-HID encoding. The inversion comes from the generic parser,
not the controller.

## Approach

Follows the Razer V3 TE precedent in
`docs/development/experimental-controllers.md`: a bundled record replacing an
ineffective Generic HID fallback. `GenericHIDParser` is untouched.

## Report layout

Report ID `0x01`, 15 bytes. Neutral:
`01 FF FF FF FF 00 00 00 00 00 00 00 00 00 00`.

| Offset | Contents |
| --- | --- |
| 1 | Left stick X, signed, `0x7F` right |
| 2 | Left stick Y, signed, `0x80` up |
| 3 | Right stick X, signed, `0x7F` right |
| 4 | Right stick Y, signed, `0x80` up |
| 9 | Low nibble D-pad hat, `1` up increasing clockwise; `0x10` A, `0x20` B, `0x40` X, `0x80` Y |
| 10 | `0x01` LB, `0x02` RB, `0x04` LT digital, `0x08` RT digital, `0x10` Select, `0x20` Start, `0x40` L3, `0x80` R3 |
| 11 | `0x01` C, `0x02` Z, `0x04` M1, `0x08` M2, `0x10` M3, `0x20` M4 |
| 12 | `0x80` Home |
| 13 | Left trigger, unsigned `0...255` |
| 14 | Right trigger, unsigned `0...255` |

Bytes 5 through 8 were `0x00` in every observed report.

The digital trigger bits in byte 10 accompany the analog values rather than
replacing them, so the parser reads trigger position from bytes 13 and 14 only.
This also covers the controller's alternate trigger mode.

C, Z, and M1 through M4 decode but have no `Button` case and no bit in the
16-button compatibility report, so they stay diagnostic-only.

## Hardware

- Flydigi Vader 4 Pro, firmware 6.9.5.5, Bluetooth Low Energy
- macOS 26.5.2 (25F84), Apple silicon
- Captured with `--headless controller packets` against the installed signed
  0.5.0-beta.3 app, one control at a time, diffed against the neutral report

The controller reports only on change, so `controller trace` returns nothing at
rest; `controller packets` was the workable capture path.

## Validation

```
./scripts/ojd catalog regenerate --check   Verified 257 canonical controller record(s).
./scripts/ojd check profiles               Validated 257 canonical controller record(s).
./scripts/ojd check schemas                Validated 3 schema documents, 257 controller records, 11 overrides
./scripts/ojd check swift-structure        Swift structure validation passed.
./scripts/ojd lint                         Found 0 violations, 0 serious in 325 files.
swift test                                 883 tests in 112 suites passed
swift test --filter FlydigiParserTests     16 tests passed
```

Catalog resolution for `D7D7:0041` confirmed against the real catalog:
`parserName: Flydigi`, `variant: flydigi`, `parser: FlydigiParser`, and the
identity is present in `hidProfileIdentifiers()`, so discovery matches it by
VID/PID rather than advertised usage.

`./scripts/ojd test parsers-macos14` fails on this branch and on clean `main` —
its harness references `DeviceRuntimeProfile.mappingFlags` and
`Button.genericButton1`, neither of which exists in `Sources/`. Verified by
stashing. Unrelated to this change.

## Not verified

Input decoding is verified against captured reports for every control in the
table. Not verified:

- consumer-visible input through the virtual device
- reconnect after the controller sleeps
- rumble or any other physical output
- the 2.4 GHz dongle and wired identities, which enumerate separately and are
  out of scope for this record

Same constraint as #27: local ad-hoc signing cannot retain
`com.apple.developer.hid.virtual.device`, and AMFI rejects a modified copy of
the signed app. Could you provide a maintainer-signed test build of this
branch? I have the hardware and will run the procedure in
`docs/testing/flydigi-vader-4-pro.md` and report results before this merges.

## Files

- `Resources/ControllerOverrides/d7d7/d7d7-0041.json` — authored override, `add`
- `Sources/OpenJoystickDriverKit/Resources/Controllers/d7d7/d7d7-0041.json` — generated
- `Sources/OpenJoystickDriverKit/Protocol/Parsers/FlydigiParser.swift` — new parser
- `Tests/OpenJoystickDriverKitTests/Protocol/Parsers/FlydigiParserTests.swift` — 16 tests from captured reports
- `docs/testing/flydigi-vader-4-pro.md` — report map, evidence status, procedure
- schema/enum/registry/contract wiring for the `Flydigi` driver, one
  localization template key, and five exhaustive switches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Flydigi Vader 4 Pro controllers over Bluetooth.
  * Added controller identification, input parsing, Xbox-style control labels, and localized display names.
  * Added support for buttons, D-pad, triggers, and analog sticks.

* **Documentation**
  * Added setup and verification guidance for Flydigi Vader 4 Pro test hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->